### PR TITLE
spring-ai-1.1.0-M4 / Docker healthcheck fix

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -12,7 +12,7 @@ on:
 
 env:
   REGISTRY: docker.io
-  IMAGE_NAME: iunera/druid-mcp-server-cshtest
+  IMAGE_NAME: iunera/druid-mcp-server
 
 jobs:
   dev-build:

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -12,7 +12,7 @@ on:
 
 env:
   REGISTRY: docker.io
-  IMAGE_NAME: iunera/druid-mcp-server-dev
+  IMAGE_NAME: iunera/druid-mcp-server-cshtest
 
 jobs:
   dev-build:
@@ -65,8 +65,6 @@ jobs:
       with:
         images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
         tags: |
-          type=raw,value=dev
-          type=raw,value=dev-${{ steps.version.outputs.version }}
           type=sha,format=short,prefix=dev-
           type=ref,event=branch,prefix=dev-
 

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -10,6 +10,10 @@ on:
       - '**'
       - '!main'  # Exclude PRs to main branch
 
+env:
+  REGISTRY: docker.io
+  IMAGE_NAME: iunera/druid-mcp-server-dev
+
 jobs:
   dev-build:
     runs-on: ubuntu-latest
@@ -18,10 +22,10 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
 
-    - name: Set up JDK 24
+    - name: Set up JDK 25
       uses: actions/setup-java@v4
       with:
-        java-version: '24'
+        java-version: '25'
         distribution: 'temurin'
 
     - name: Cache Maven dependencies
@@ -44,14 +48,44 @@ jobs:
     - name: Build application
       run: mvn clean package -DskipTests
 
-    - name: Build Docker image (no push)
-      run: docker build -t druid-mcp-server:dev .
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Log in to Docker Hub
+      if: github.event_name == 'push'
+      uses: docker/login-action@v3
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+    - name: Extract Docker metadata (tags, labels)
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+        tags: |
+          type=raw,value=dev
+          type=raw,value=dev-${{ steps.version.outputs.version }}
+          type=sha,format=short,prefix=dev-
+
+    - name: Build and push Docker image (dev)
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        platforms: linux/amd64,linux/arm64
+        push: ${{ github.event_name == 'push' }}
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
 
     - name: Display build summary
       run: |
         echo "✅ Development build completed successfully!"
         echo "🏷️ Version: ${{ steps.version.outputs.version }}"
         echo "📦 JAR file: $(ls target/*.jar)"
-        echo "🐳 Docker image: druid-mcp-server:dev"
+        echo "🐳 Docker image pushed: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }} with tags:"
+        echo "${{ steps.meta.outputs.tags }}"
         echo "🔧 Branch: ${{ github.ref_name }}"
         echo "📝 Commit: ${{ github.sha }}"

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -68,6 +68,7 @@ jobs:
           type=raw,value=dev
           type=raw,value=dev-${{ steps.version.outputs.version }}
           type=sha,format=short,prefix=dev-
+          type=ref,event=branch,prefix=dev-
 
     - name: Build and push Docker image (dev)
       uses: docker/build-push-action@v5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,6 @@ The format is based on Keep a Changelog and this project adheres to Semantic Ver
 
 ## [1.5.2] - 2025-11-05
 
-### Added
-- Prepare release: bump version, update documentation and metadata, and finalize release automation.
-
 ### Changed
 - Dependency refreshes.
 - Spring AI: upgraded `spring.ai` from `1.1.0-M3` to `1.1.0-M4`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog and this project adheres to Semantic Versioning.
 
+### Added
+- Prepare release: bump version, update documentation and metadata, and finalize release automation.
+
+### Changed
+- Dependency refreshes.
+- Spring AI: upgraded `spring.ai` from `1.1.0-M3` to `1.1.0-M4`
+- Updated MCP SDK to `0.15.0`: unified request context API, improved autoconfiguration for MCP tool initialization, and fixed tool callback provider injection issues.
+- Dockerfile improvements and healthcheck fix:
+  - Reworked to a multi-stage build with a dedicated `deps` stage to cache Maven dependencies and reuse the local repository, reducing image build time.
+  - Upgraded base build/runtime images to Eclipse Temurin 25.
+  - Switched the container healthcheck to use `nc -z localhost 8080` (netcat) instead of `curl`. 
+
+Full Changelog: https://github.com/iunera/druid-mcp-server/compare/v1.5.1...v1.5.2
+
 ## [1.5.1] - 2025-10-15
 
 ### Fix
@@ -54,7 +68,7 @@ Configurable Environment Variable `DRUID_MCP_READONLY` is now `DRUID_MCP_READONL
 ### Changed
 - Refactored Druid configuration classes.
 
-Full Changelog: https://github.com/iunera/druid-mcp-server/compare/v1.2.2...oauth2
+Full Changelog: https://github.com/iunera/druid-mcp-server/compare/v1.2.2...v1.3.0
 
 ## [1.2.2] - 2025-09-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog and this project adheres to Semantic Versioning.
 
+## [1.5.2] - 2025-11-05
+
 ### Added
 - Prepare release: bump version, update documentation and metadata, and finalize release automation.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Multi-stage build for Spring Boot application
-FROM maven:3-eclipse-temurin-24 AS build
+FROM maven:3-eclipse-temurin-25 AS build
 
 # Set working directory
 WORKDIR /app
@@ -14,7 +14,7 @@ COPY src ./src
 RUN mvn clean package
 
 # Runtime stage
-FROM eclipse-temurin:24-jre
+FROM eclipse-temurin:25-jre
 
 # Add MCP server metadata labels
 LABEL io.modelcontextprotocol.server.name="com.iunera/druid-mcp-server"

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Note on Spring profiles:
 mvn clean package -DskipTests
 
 # Run the application
-java -jar target/druid-mcp-server-1.5.1.jar
+java -jar target/druid-mcp-server-1.5.2.jar
 ```
 
 The server will start on port 8080 by default.
@@ -137,11 +137,11 @@ Download the JAR from Maven Central https://repo.maven.apache.org/maven2/com/iun
 
 ```bash
 # STDIO mode (default)
-java -jar target/druid-mcp-server-1.5.1.jar
+java -jar target/druid-mcp-server-1.5.2.jar
 
 # HTTP mode (profile: http) - exposes /mcp on port 8080
 java -Dspring.profiles.active=http \
-     -jar target/druid-mcp-server-1.5.1.jar
+     -jar target/druid-mcp-server-1.5.2.jar
 ```
 
 ## For Developers
@@ -310,7 +310,7 @@ export DRUID_SSL_ENABLED="true"
 export DRUID_SSL_SKIP_VERIFICATION="false"  # Use "true" only for testing
 
 # Start the MCP server
-java -jar target/druid-mcp-server-1.5.1.jar
+java -jar target/druid-mcp-server-1.5.2.jar
 ```
 
 ##### Method 2: Runtime System Properties
@@ -321,7 +321,7 @@ Pass configuration as JVM system properties:
 java -Ddruid.router.url="http://localhost:8888" \
      -Ddruid.auth.username="admin" \
      -Ddruid.auth.password="password" \
-     -jar target/druid-mcp-server-1.5.1.jar
+     -jar target/druid-mcp-server-1.5.2.jar
 ```
 
 #### SSL Configuration Options
@@ -374,7 +374,7 @@ Update your `mcp-servers-config.json` to include environment variables:
         "DRUID_SSL_SKIP_VERIFICATION",
         "-e",
         "DRUID_MCP_READONLY_ENABLED",
-        "iunera/druid-mcp-server:1.5.1"
+        "iunera/druid-mcp-server:1.5.2"
       ],
       "env": {
         "DRUID_ROUTER_URL": "http://host.docker.internal:8888",
@@ -411,7 +411,7 @@ You can override any prompt template using Java system properties with the `-D` 
 
 ```bash
 java -Dprompts.druid-data-exploration.template="Your custom template here" \
-     -jar target/druid-mcp-server-1.5.1.jar
+     -jar target/druid-mcp-server-1.5.2.jar
 ```
 
 #### Method 2: Custom Properties File
@@ -429,7 +429,7 @@ Environment: {environment}
 2. Load it at runtime:
 ```bash
 java -Dspring.config.additional-location=classpath:custom-prompts.properties \
-     -jar target/druid-mcp-server-1.5.1.jar
+     -jar target/druid-mcp-server-1.5.2.jar
 ```
 
 ### Available Prompt Variables
@@ -497,7 +497,7 @@ The new **Streamable HTTP** transport provides enhanced performance and scalabil
 # Default configuration with Streamable HTTP
 
 java -Dspring.profiles.active=http \
-     -jar target/druid-mcp-server-1.5.1.jar
+     -jar target/druid-mcp-server-1.5.2.jar
 # Server available at http://localhost:8080/mcp (configurable endpoint)
 ```
 
@@ -517,7 +517,7 @@ Security
 Perfect for LLM clients and desktop applications:
 
 ```bash
-java -jar target/druid-mcp-server-1.5.1.jar
+java -jar target/druid-mcp-server-1.5.2.jar
 ```
 
 #### Legacy SSE Transport (Deprecated)
@@ -554,7 +554,7 @@ export DRUID_MCP_READONLY_ENABLED=true
 3) JVM system property
 
 ```bash
-java -Ddruid.mcp.readonly.enabled=true -jar target/druid-mcp-server-1.5.1.jar
+java -Ddruid.mcp.readonly.enabled=true -jar target/druid-mcp-server-1.5.2.jar
 ```
 
 4) Docker

--- a/development.md
+++ b/development.md
@@ -80,7 +80,7 @@ The Inspector provides a web UI and a CLI to list tools/resources/prompts, call 
 #### Start the Druid MCP Server
 
 ```bash
-java -jar target/druid-mcp-server-1.5.1.jar
+java -jar target/druid-mcp-server-1.5.2.jar
 ```
 
 Or Using Docker (HTTP/SSE):
@@ -392,7 +392,7 @@ For every Resource we need a separate Tool to access it in addition.
 java -Dspring.ai.mcp.server.stdio=true \
      -Dspring.main.web-application-type=none \
      -Dlogging.pattern.console= \
-     -jar target/druid-mcp-server-1.5.1.jar
+     -jar target/druid-mcp-server-1.5.2.jar
 ```
 
 

--- a/examples/stdio/README.md
+++ b/examples/stdio/README.md
@@ -13,7 +13,7 @@ That file makes your client start the server using Docker with all important env
 
 ## What the config does
 
-- Uses Docker image: iunera/druid-mcp-server:1.5.1
+- Uses Docker image: iunera/druid-mcp-server:1.5.2
 - Starts the container in STDIO mode via environment variables
 - Passes Druid connection settings via environment variables
 
@@ -28,7 +28,7 @@ docker run --rm -i \
   -e DRUID_COORDINATOR_URL=http://host.docker.internal:8081 \
   -e DRUID_AUTH_USERNAME=admin \
   -e DRUID_AUTH_PASSWORD=password \
-  iunera/druid-mcp-server:1.5.1
+  iunera/druid-mcp-server:1.5.2
 ```
 
 Tip: Replace DRUID_ROUTER_URL and add DRUID_AUTH_USERNAME/DRUID_AUTH_PASSWORD and TLS flags when connecting to a secured Druid.

--- a/examples/streamable-http/README.md
+++ b/examples/streamable-http/README.md
@@ -22,7 +22,7 @@ docker run --rm -p 8080:8080 \
   -e DRUID_COORDINATOR_URL=http://host.docker.internal:8081 \
   -e DRUID_AUTH_USERNAME=admin \
   -e DRUID_AUTH_PASSWORD=password \
-  iunera/druid-mcp-server:1.5.1
+  iunera/druid-mcp-server:1.5.2
 ```
 
 2) Obtain a token using client-credentials grant (default client: `oidc-client` / `secret`):

--- a/mcp-registry.md
+++ b/mcp-registry.md
@@ -143,7 +143,7 @@ Ensure your `server.json` is up-to-date with the latest version and metadata:
       "transport": {
         "type": "stdio",
         "command": "docker",
-        "args": ["run", "--rm", "-i", "iunera/druid-mcp-server:1.5.1"]
+        "args": ["run", "--rm", "-i", "iunera/druid-mcp-server:1.5.2"]
       }
     }
   ]
@@ -198,7 +198,7 @@ When releasing a new version:
 - [ ] `pom.xml` version: `1.2.1`
 - [ ] `server.json` version: `1.2.1`
 - [ ] `server.json` package version: `1.2.1`
-- [ ] Docker image tag: `iunera/druid-mcp-server:1.5.1`
+- [ ] Docker image tag: `iunera/druid-mcp-server:1.5.2`
 - [ ] All example configurations updated
 
 ## Troubleshooting

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
     </scm>
 
     <properties>
-        <java.version>25</java.version>
+        <java.version>24</java.version>
         <spring.ai.version>1.1.0-M4</spring.ai.version>
     </properties>
 
@@ -182,7 +182,7 @@
                         </executions>
                         <configuration>
                             <doclint>none</doclint>
-                            <source>25</source>
+                            <source>24</source>
                         </configuration>
                     </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -182,7 +182,7 @@
                         </executions>
                         <configuration>
                             <doclint>none</doclint>
-                            <source>24</source>
+                            <source>25</source>
                         </configuration>
                     </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     </parent>
     <groupId>com.iunera</groupId>
     <artifactId>druid-mcp-server</artifactId>
-    <version>1.5.1</version>
+    <version>1.5.2</version>
     <name>druid-mcp-server</name>
     <description>A comprehensive Model Context Protocol (MCP) server for Apache Druid that provides AI-assisted tools, resources, and prompts for managing and
         analyzing Druid clusters. Built with Spring Boot and Spring AI, this server enables seamless integration between Large Language Models and Apache Druid
@@ -62,8 +62,8 @@
     </scm>
 
     <properties>
-        <java.version>24</java.version>
-        <spring.ai.version>1.1.0-M3</spring.ai.version>
+        <java.version>25</java.version>
+        <spring.ai.version>1.1.0-M4</spring.ai.version>
     </properties>
 
     <dependencyManagement>

--- a/server.json
+++ b/server.json
@@ -6,11 +6,11 @@
     "url": "https://github.com/iunera/druid-mcp-server",
     "source": "github"
   },
-  "version": "1.5.1",
+  "version": "1.5.2",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "docker.io/iunera/druid-mcp-server:1.5.1",
+      "identifier": "docker.io/iunera/druid-mcp-server:1.5.2",
       "runtimeHint": "docker",
       "transport": {
         "type": "stdio",

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -25,7 +25,7 @@ spring:
     mcp:
       server:
         name: druid-mcp-server
-        version: 1.5.1
+        version: 1.5.2
 
 druid:
   router:


### PR DESCRIPTION
## Changed
- Dependency refreshes.
- Spring AI: upgraded `spring.ai` from `1.1.0-M3` to `1.1.0-M4`
- Updated MCP SDK to `0.15.0`: unified request context API, improved autoconfiguration for MCP tool initialization, and fixed tool callback provider injection issues.
- Dockerfile improvements and healthcheck fix:
  - Reworked to a multi-stage build with a dedicated `deps` stage to cache Maven dependencies and reuse the local repository, reducing image build time.
  - Upgraded base build/runtime images to Eclipse Temurin 25.
  - Switched the container healthcheck to use `nc -z localhost 8080` (netcat) instead of `curl`. 
