### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@ A comprehensive Model Context Protocol (MCP) server for Apache Druid that provid
 
 *Developed by [iunera](https://www.iunera.com) - Advanced AI and Data Analytics Solutions*
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/iunera-druid-mcp-server).
+
 ## Overview
 
 This MCP server implements a feature-based architecture where each package represents a distinct functional area of Druid management. The server provides three main types of MCP components:


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/iunera-druid-mcp-server).